### PR TITLE
Fix packet decoding

### DIFF
--- a/src/main/java/com/extendedclip/papi/expansion/pinger/PingerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/pinger/PingerExpansion.java
@@ -294,7 +294,7 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     return false;
                 }
                 String string = new String(chars);
-                if (string.startsWith("&")) {
+                if (string.startsWith("§")) {
                     String[] data = string.split("\000");
                     setPingVersion(Integer.parseInt(data[0].substring(1)));
                     setProtocolVersion(Integer.parseInt(data[1]));
@@ -303,7 +303,7 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     setPlayersOnline(Integer.parseInt(data[4]));
                     setMaxPlayers(Integer.parseInt(data[5]));
                 } else {
-                    String[] data = string.split("&");
+                    String[] data = string.split("§");
                     setMotd(data[0]);
                     setPlayersOnline(Integer.parseInt(data[1]));
                     setMaxPlayers(Integer.parseInt(data[2]));

--- a/src/main/java/com/extendedclip/papi/expansion/pinger/PingerExpansion.java
+++ b/src/main/java/com/extendedclip/papi/expansion/pinger/PingerExpansion.java
@@ -12,7 +12,7 @@ import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -248,8 +248,19 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                 DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
                 InputStream inputStream = socket.getInputStream();
                 InputStreamReader inputStreamReader = new InputStreamReader(inputStream,
-                        Charset.forName("UTF-16BE"));
-                dataOutputStream.write(new byte[]{-2, 1});
+                        StandardCharsets.UTF_16BE);
+
+                // Send server list ping request, in 1.4-1.5 format
+                // See https://wiki.vg/Server_List_Ping#1.4_to_1.5
+                dataOutputStream.write(0xFE);
+                dataOutputStream.write(0x01);
+
+                // Then, read the ping response (a kick packet)
+                // Beta 1.8 - 1.3 servers should respond with this format: https://wiki.vg/Server_List_Ping#Beta_1.8_to_1.3
+                // 1.4+ servers should respond with this format: https://wiki.vg/Server_List_Ping#1.4_to_1.5
+                // which uses the same response format as: https://wiki.vg/Server_List_Ping#1.6
+
+                // Read packet ID field (1 byte), should be 0xFF (kick packet ID)
                 int packetId = inputStream.read();
                 if (packetId == -1) {
                     try {
@@ -259,7 +270,7 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     socket = null;
                     return false;
                 }
-                if (packetId != 255) {
+                if (packetId != 0xFF) {
                     try {
                         socket.close();
                     } catch (IOException iOException) {
@@ -267,6 +278,8 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     socket = null;
                     return false;
                 }
+
+                // Read string length field (2 bytes)
                 int length = inputStreamReader.read();
                 if (length == -1) {
                     try {
@@ -284,6 +297,8 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     socket = null;
                     return false;
                 }
+
+                // Read string (length bytes)
                 char[] chars = new char[length];
                 if (inputStreamReader.read(chars, 0, length) != length) {
                     try {
@@ -294,8 +309,15 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     return false;
                 }
                 String string = new String(chars);
+
+                // Read the fields of the string
                 if (string.startsWith("§")) {
-                    String[] data = string.split("\000");
+                    // If the string starts with '§', the server is probably running 1.4+
+                    // See https://wiki.vg/Server_List_Ping#1.4_to_1.5
+                    // and https://wiki.vg/Server_List_Ping#1.6
+
+                    // In this format, fields are delimited by '\0' characters
+                    String[] data = string.split("\0");
                     setPingVersion(Integer.parseInt(data[0].substring(1)));
                     setProtocolVersion(Integer.parseInt(data[1]));
                     setGameVersion(data[2]);
@@ -303,6 +325,10 @@ public class PingerExpansion extends PlaceholderExpansion implements Cacheable, 
                     setPlayersOnline(Integer.parseInt(data[4]));
                     setMaxPlayers(Integer.parseInt(data[5]));
                 } else {
+                    // If the string doesn't start with '§', the server is probably running Beta 1.8 - 1.3
+                    // See https://wiki.vg/Server_List_Ping#Beta_1.8_to_1.3
+
+                    // In this format, fields are delimited by '§' characters
                     String[] data = string.split("§");
                     setMotd(data[0]);
                     setPlayersOnline(Integer.parseInt(data[1]));


### PR DESCRIPTION
NOTE: This PR does ***not*** provide a solution for #2

As explained in https://github.com/PlaceholderAPI/Pinger-Expansion/issues/2#issuecomment-1453463643, the source code uploaded to this repository differs from the source code that was used to build the JAR file which has been uploaded to eCloud. Commit 0128494c1104e666d696f4abbb10838371734394 reverts the seemingly accidental change to the source code, which means that the plugin once again works if built from this source code. Commit 2c8819528da56071fb3f1bf96d0bf95b88c29346 should contain no behavioral changes to the code, it's just a slight rewrite to improve the clarity, by using hexadecimal notation for magic bytes and adding some comments to explain the code.

I have tested that:
- Before these changes, the plugin (built from the source code, not the eCloud version) doesn't work at all, the placeholders just return empty strings
- After these changes, the plugin once again works the same way as the eCloud version